### PR TITLE
Multiple origins

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,41 +17,56 @@ const DEFAULT_ALLOW_HEADERS = [
 
 const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 // 24 hours
 
-const cors = options => handler => (req, res) => {
+const checkOrigin = (origin, allowed) => {
+  if (Array.isArray(allowed)) return !!allowed.find(a => a === origin)
+  if (typeof allowed === 'function') return allowed(origin)
+  if (allowed instanceof RegExp) return allowed.test(origin)
+  return !!allowed
+}
+
+const cors = options => {
   const {
     maxAge,
-    origin,
+    origin = '*',
     allowHeaders,
     allowMethods,
   } = (options || {})
 
-  res.setHeader(
-    'Access-Control-Max-Age',
-    '' + (maxAge || DEFAULT_MAX_AGE_SECONDS)
-  )
+  return handler => (req, res) => {
 
-  res.setHeader(
-    'Access-Control-Allow-Origin',
-    (origin || '*')
-  )
+    res.setHeader(
+      'Access-Control-Max-Age',
+      '' + (maxAge || DEFAULT_MAX_AGE_SECONDS)
+    )
 
-  res.setHeader(
-    'Access-Control-Allow-Methods',
-    (allowMethods || DEFAULT_ALLOW_METHODS).join(',')
-  )
+    if (typeof origin === 'string') {
+      res.setHeader('Access-Control-Allow-Origin', origin)
+    } else if(checkOrigin(req.headers.origin, origin)) {
+      res.setHeader(
+        'Access-Control-Allow-Origin',
+        req.headers.origin
+      )
+    }
+    if (origin !== '*') res.setHeader('Vary', 'Origin')
 
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    (allowHeaders || DEFAULT_ALLOW_HEADERS).join(',')
-  )
+    res.setHeader(
+      'Access-Control-Allow-Methods',
+      (allowMethods || DEFAULT_ALLOW_METHODS).join(',')
+    )
 
-  res.setHeader('Access-Control-Allow-Credentials', 'true')
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      (allowHeaders || DEFAULT_ALLOW_HEADERS).join(',')
+    )
 
-  if (req.method === 'OPTIONS') {
-    return {}
+    res.setHeader('Access-Control-Allow-Credentials', 'true')
+
+    if (req.method === 'OPTIONS') {
+      return {}
+    }
+
+    return handler(req, res)
   }
-
-  return handler(req, res)
 }
 
 module.exports = cors

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ava": "0.17.0",
     "babel-polyfill": "6.20.0",
     "micro": "6.2.0",
+    "request": "^2.81.0",
     "request-promise": "4.1.1",
     "test-listen": "1.0.0"
   }

--- a/test.js
+++ b/test.js
@@ -94,6 +94,63 @@ test('adds configured allow origin header', async t => {
   }
 })
 
+test('adds allowed header when origin is a function', async t => {
+  const cors = microCors({ origin: o => o === 'BAZ' })
+  const router = micro(cors(() => ({})))
+  const url = await listen(router)
+
+  for (let method of methods) {
+    const response = await request({
+      url,
+      method,
+      headers: { Origin: 'BAZ' },
+      ...testRequestOptions,
+    })
+
+    const allowOriginHeader =
+      response.headers['access-control-allow-origin']
+    t.deepEqual(allowOriginHeader, 'BAZ')
+  }
+})
+
+test('adds allowed header when origin is a regex', async t => {
+  const cors = microCors({ origin: /^BAZ$/ })
+  const router = micro(cors(() => ({})))
+  const url = await listen(router)
+
+  for (let method of methods) {
+    const response = await request({
+      url,
+      method,
+      headers: { Origin: 'BAZ' },
+      ...testRequestOptions,
+    })
+
+    const allowOriginHeader =
+      response.headers['access-control-allow-origin']
+    t.deepEqual(allowOriginHeader, 'BAZ')
+  }
+})
+
+test('adds allowed header when origin is an array', async t => {
+  const cors = microCors({ origin: ['FOO', 'BAR', 'BAZ'] })
+  const router = micro(cors(() => ({})))
+  const url = await listen(router)
+
+  for (let method of methods) {
+    const response = await request({
+      url,
+      method,
+      headers: { Origin: 'BAZ' },
+      ...testRequestOptions,
+    })
+
+    const allowOriginHeader =
+      response.headers['access-control-allow-origin']
+    t.deepEqual(allowOriginHeader, 'BAZ')
+  }
+})
+
 test('adds default allow methods header', async t => {
   const cors = microCors()
   const router = micro(cors(() => ({})))


### PR DESCRIPTION
**Add support for multiple origins**

with this patch, origin may be defined as one of:
- a string (default '*')
- a regex
- a function (returning a boolean)
- an array of strings

this also moves the const declaration outside of the middleware function, which is a minor performance optimization.

This PR also adds the `request` dependency, as it's a peer of `request-promise` but will not be installed by default.

Resolves #8 