### PR TITLE
fix(OPTIONS): return correct hander

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -48,10 +48,6 @@ const cors = options => handler => (req, res) => {
 
   res.setHeader('Access-Control-Allow-Credentials', 'true')
 
-  if (req.method === 'OPTIONS') {
-    return {}
-  }
-
   return handler(req, res)
 }
 


### PR DESCRIPTION
I want to use CORS feature with OPTIONS handler.
Is there any reason to return a empty object?