### PR TITLE
Simplify code

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ yarn add micro-cors
 Basic
 
 ```js
+const { send } = require('micro')
 const cors = require('micro-cors')()
 const handler = (req, res) => send(res, 200, 'ok!')
 
@@ -26,6 +27,7 @@ module.exports = cors(handler)
 With options
 
 ```js
+const { send } = require('micro')
 const microCors = require('micro-cors')
 const cors = microCors({ allowMethods: ['PUT', 'POST'] })
 const handler = (req, res) => send(res, 200, 'ok!')
@@ -35,22 +37,22 @@ module.exports = cors(handler)
 
 #### Options
 
-##### `allowMethods`
+##### `allowMethods` &lt;String>
 
-default: `['POST','GET','PUT','DELETE','OPTIONS']`
+default: `'POST,GET,PUT,PATCH,DELETE,OPTIONS'`
 
-##### `allowHeaders`
+##### `allowHeaders` &lt;String>
 
-default: `['X-Requested-With','Access-Control-Allow-Origin','X-HTTP-Method-Override','Content-Type','Authorization','Accept']`
+default: `'X-Requested-With,Access-Control-Allow-Origin,X-HTTP-Method-Override,Content-Type,Authorization,Accept'`
 
-##### `exposeHeaders`
+##### `exposeHeaders` &lt;String>
 
-default: `[]`
+default: `undefined`
 
-##### `maxAge`
+##### `maxAge` &lt;String>
 
 default: `86400`
 
-##### `origin`
+##### `origin` &lt;String>
 
 default: `*`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ yarn add micro-cors
 Basic
 
 ```js
-const { send } = require('micro')
 const cors = require('micro-cors')()
 const handler = (req, res) => send(res, 200, 'ok!')
 
@@ -27,7 +26,6 @@ module.exports = cors(handler)
 With options
 
 ```js
-const { send } = require('micro')
 const microCors = require('micro-cors')
 const cors = microCors({ allowMethods: ['PUT', 'POST'] })
 const handler = (req, res) => send(res, 200, 'ok!')
@@ -37,22 +35,22 @@ module.exports = cors(handler)
 
 #### Options
 
-##### `allowMethods` &lt;String>
+##### `allowMethods`
 
-default: `'POST,GET,PUT,PATCH,DELETE,OPTIONS'`
+default: `['POST','GET','PUT','DELETE','OPTIONS']`
 
-##### `allowHeaders` &lt;String>
+##### `allowHeaders`
 
-default: `'X-Requested-With,Access-Control-Allow-Origin,X-HTTP-Method-Override,Content-Type,Authorization,Accept'`
+default: `['X-Requested-With','Access-Control-Allow-Origin','X-HTTP-Method-Override','Content-Type','Authorization','Accept']`
 
-##### `exposeHeaders` &lt;String>
+##### `exposeHeaders`
 
-default: `undefined`
+default: `[]`
 
-##### `maxAge` &lt;String>
+##### `maxAge`
 
 default: `86400`
 
-##### `origin` &lt;String>
+##### `origin`
 
 default: `*`

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 // 24 hours
-
 const DEFAULT_ALLOW_METHODS = [
   'POST',
   'GET',
@@ -18,22 +16,24 @@ const DEFAULT_ALLOW_HEADERS = [
   'Accept'
 ]
 
+const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 // 24 hours
+
 const cors = options => handler => (req, res, ...restArgs) => {
   const {
     origin = '*',
     maxAge = DEFAULT_MAX_AGE_SECONDS,
     allowMethods = DEFAULT_ALLOW_METHODS,
     allowHeaders = DEFAULT_ALLOW_HEADERS,
-    exposeHeaders
+    exposeHeaders = []
   } = (options || {})
 
   res.setHeader('Access-Control-Allow-Credentials', 'true')
-  res.setHeader('Access-Control-Max-Age', maxAge)
+  res.setHeader('Access-Control-Max-Age', String(maxAge))
   res.setHeader('Access-Control-Allow-Origin', origin)
   res.setHeader('Access-Control-Allow-Methods', allowMethods.join(','))
   res.setHeader('Access-Control-Allow-Headers', allowHeaders.join(','))
 
-  if (exposeHeaders instanceof Array) {
+  if (exposeHeaders.length) {
     res.setHeader('Access-Control-Expose-Headers', exposeHeaders.join(','))
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,14 @@
 const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 // 24 hours
-const DEFAULT_ALLOW_METHODS = 'POST,GET,PUT,PATCH,DELETE,OPTIONS'
+
+const DEFAULT_ALLOW_METHODS = [
+  'POST',
+  'GET',
+  'PUT',
+  'PATCH',
+  'DELETE',
+  'OPTIONS'
+]
+
 const DEFAULT_ALLOW_HEADERS = [
   'X-Requested-With',
   'Access-Control-Allow-Origin',
@@ -7,7 +16,7 @@ const DEFAULT_ALLOW_HEADERS = [
   'Content-Type',
   'Authorization',
   'Accept'
-].join(',')
+]
 
 const cors = options => handler => (req, res, ...restArgs) => {
   const {
@@ -21,11 +30,11 @@ const cors = options => handler => (req, res, ...restArgs) => {
   res.setHeader('Access-Control-Allow-Credentials', 'true')
   res.setHeader('Access-Control-Max-Age', maxAge)
   res.setHeader('Access-Control-Allow-Origin', origin)
-  res.setHeader('Access-Control-Allow-Methods', allowMethods)
-  res.setHeader('Access-Control-Allow-Headers', allowHeaders)
+  res.setHeader('Access-Control-Allow-Methods', allowMethods.join(','))
+  res.setHeader('Access-Control-Allow-Headers', allowHeaders.join(','))
 
-  if (typeof exposeHeaders === 'string') {
-    res.setHeader('Access-Control-Expose-Headers', exposeHeaders)
+  if (exposeHeaders instanceof Array) {
+    res.setHeader('Access-Control-Expose-Headers', exposeHeaders.join(','))
   }
 
   return handler(req, res, ...restArgs)

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,5 @@
-const DEFAULT_ALLOW_METHODS = [
-  'POST',
-  'GET',
-  'PUT',
-  'PATCH',
-  'DELETE',
-  'OPTIONS'
-]
-
+const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 // 24 hours
+const DEFAULT_ALLOW_METHODS = 'POST,GET,PUT,PATCH,DELETE,OPTIONS'
 const DEFAULT_ALLOW_HEADERS = [
   'X-Requested-With',
   'Access-Control-Allow-Origin',
@@ -14,47 +7,26 @@ const DEFAULT_ALLOW_HEADERS = [
   'Content-Type',
   'Authorization',
   'Accept'
-]
-
-const DEFAULT_MAX_AGE_SECONDS = 60 * 60 * 24 // 24 hours
+].join(',')
 
 const cors = options => handler => (req, res, ...restArgs) => {
   const {
-    maxAge,
-    origin,
-    allowHeaders,
-    exposeHeaders,
-    allowMethods
+    origin = '*',
+    maxAge = DEFAULT_MAX_AGE_SECONDS,
+    allowMethods = DEFAULT_ALLOW_METHODS,
+    allowHeaders = DEFAULT_ALLOW_HEADERS,
+    exposeHeaders
   } = (options || {})
 
-  res.setHeader(
-    'Access-Control-Max-Age',
-    '' + (maxAge || DEFAULT_MAX_AGE_SECONDS)
-  )
-
-  res.setHeader(
-    'Access-Control-Allow-Origin',
-    (origin || '*')
-  )
-
-  res.setHeader(
-    'Access-Control-Allow-Methods',
-    (allowMethods || DEFAULT_ALLOW_METHODS).join(',')
-  )
-
-  res.setHeader(
-    'Access-Control-Allow-Headers',
-    (allowHeaders || DEFAULT_ALLOW_HEADERS).join(',')
-  )
-
-  if (exposeHeaders && exposeHeaders.length) {
-    res.setHeader(
-      'Access-Control-Expose-Headers',
-      exposeHeaders.join(',')
-    )
-  }
-
   res.setHeader('Access-Control-Allow-Credentials', 'true')
+  res.setHeader('Access-Control-Max-Age', maxAge)
+  res.setHeader('Access-Control-Allow-Origin', origin)
+  res.setHeader('Access-Control-Allow-Methods', allowMethods)
+  res.setHeader('Access-Control-Allow-Headers', allowHeaders)
+
+  if (typeof exposeHeaders === 'string') {
+    res.setHeader('Access-Control-Expose-Headers', exposeHeaders)
+  }
 
   return handler(req, res, ...restArgs)
 }


### PR DESCRIPTION
Like this small & pure lib, and I think it can be even simpler, here's the changes:
- Use default value in destructing assignment to further simplify codebase (51 -> 29 sloc), but which cause a breaking change:
- All options (including `allowMethods`, `allowHeaders`, `exposeHeaders`) need to be `String` type.

Since those header should be converted(internally) to a string anyway, and it's a string in the spec too, so I think the second(breaking) change is straightforward and acceptable.

What do you think? @possibilities 