### PR TITLE
 added info that micro-cors only sets headers + example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,27 @@ const handler = (req, res) => send(res, 200, 'ok!')
 module.exports = cors(handler)
 ```
 
+Since the current version of micro-cors only sets headers to the response you have do some manual work. Lets say you only want to handle POST request:
+
+```js
+const { send } = require('micro')
+const cors = require('micro-cors')()
+const handler = (req, res) => {
+  if (req.method !== 'OPTIONS') {
+    return send(res, 200, 'ok!');
+  }
+
+  if (req.method !== 'POST') {
+    throw createError(404, 'Not Found');
+  }
+
+  // handle incoming request as usual
+
+}
+
+module.exports = cors(handler)
+```
+
 With options
 
 ```js

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Since the current version of micro-cors only set headers to the response (`res`)
 const { send } = require('micro')
 const cors = require('micro-cors')()
 const handler = (req, res) => {
-  if (req.method !== 'OPTIONS') {
+  if (req.method === 'OPTIONS') {
     return send(res, 200, 'ok!');
   }
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ const handler = (req, res) => send(res, 200, 'ok!')
 module.exports = cors(handler)
 ```
 
-Since the current version of micro-cors only set headers to the response (`res`) you have do some manual work. Lets say you only want to handle a POST request:
+Since the current version of `micro-cors` only sets headers in the response (`res`), you have do some manual work if you want to avoid triggering your handler on an `OPTIONS` preflight request. Let's say you want to approve preflight requests and otherwise only let POST requests trigger the handler:
 
 ```js
 const { send } = require('micro')
 const cors = require('micro-cors')()
+
 const handler = (req, res) => {
   if (req.method === 'OPTIONS') {
     return send(res, 200, 'ok!');
@@ -41,7 +42,6 @@ const handler = (req, res) => {
   }
 
   // handle incoming request as usual
-
 }
 
 module.exports = cors(handler)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const handler = (req, res) => send(res, 200, 'ok!')
 module.exports = cors(handler)
 ```
 
-Since the current version of `micro-cors` only sets headers in the response (`res`), you have do some manual work if you want to avoid triggering your handler on an `OPTIONS` preflight request. Let's say you want to approve preflight requests and otherwise only let POST requests trigger the handler:
+Since the current version of `micro-cors` only sets headers in the response (`res`), you have do some manual work if you want to avoid triggering your handler on an `OPTIONS` preflight request (this will be built-in in v1). Let's say you want to approve preflight requests and otherwise only let POST requests trigger the handler:
 
 ```js
 const { send } = require('micro')

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ const handler = (req, res) => send(res, 200, 'ok!')
 module.exports = cors(handler)
 ```
 
-Since the current version of micro-cors only sets headers to the response you have do some manual work. Lets say you only want to handle POST request:
+Since the current version of micro-cors only set headers to the response (`res`) you have do some manual work. Lets say you only want to handle a POST request:
 
 ```js
 const { send } = require('micro')


### PR DESCRIPTION
I was confused the whole day before I read the source code and figured that the current version of micro-cors does not handle OPTIONS requests by it self. 

So, was clarifying this.