### PR TITLE
Change variable name for clarity and correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,6 @@ default: `*`
 
 Accepts string, regex, or array of string and/or regex values
 
-##### `runHandlerOnOptionsRequest`
+##### `runHandlerOnPreflightRequest`
 
 default: `false`

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ const cors = (options = {}) => handler => async (req, res, ...restArgs) => {
     allowHeaders = DEFAULT_ALLOW_HEADERS,
     allowCredentials = true,
     exposeHeaders = [],
-    runHandlerOnOptionsRequest = false
+    runHandlerOnPreflightRequest = false
   } = options
 
   if (!req.headers.origin) {
@@ -84,7 +84,7 @@ const cors = (options = {}) => handler => async (req, res, ...restArgs) => {
     res.setHeader('Access-Control-Max-Age', String(maxAge))
   }
 
-  if (preFlight && !runHandlerOnOptionsRequest) {
+  if (preFlight && !runHandlerOnPreflightRequest) {
     setVaryHeader(res, origin)
     res.end()
   } else {

--- a/src/test.js
+++ b/src/test.js
@@ -251,7 +251,7 @@ test('responds to OPTIONS requests without running handler', async t => {
 })
 
 test('allows to run handler on OPTIONS request', async t => {
-  const cors = microCors({ runHandlerOnOptionsRequest: true })
+  const cors = microCors({ runHandlerOnPreflightRequest: true })
   let isHandlerCalled = false
   const router = micro(cors((req, res) => {
     isHandlerCalled = true


### PR DESCRIPTION
This changes `runHandlerOnOptionsRequest` to `runHandlerOnPreflightRequest`.

It's called a Preflight Request in the spec so we should call it that too. 

Closes #59 