### PR TITLE
Return if response is finished

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,10 @@ const cors = (options = {}) => handler => (req, res, ...restArgs) => {
     exposeHeaders = []
   } = options
 
+  if (res && res.finished) {
+    return
+  }
+  
   res.setHeader('Access-Control-Allow-Origin', origin)
   if (allowCredentials) {
     res.setHeader('Access-Control-Allow-Credentials', 'true')


### PR DESCRIPTION
I found that sometimes I would have a response coming through the micro-cors middleware that already had a finished response, so this change prevents the appearance of `Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client`